### PR TITLE
Add support for ATSC x.y channel numbers

### DIFF
--- a/1080i/DialogFullScreenInfo.xml
+++ b/1080i/DialogFullScreenInfo.xml
@@ -28,7 +28,7 @@
           <control type="label" description="Main label">
             <include>FullscreenInfoLabelMain</include>
             <wrapmultiline>true</wrapmultiline>
-            <label>$INFO[VideoPlayer.TVShowTitle,,[COLOR=Highlight]  •  [/COLOR]]$INFO[VideoPlayer.Season,$LOCALIZE[31973],.]$INFO[VideoPlayer.Episode,,[COLOR=Highlight]  •  [/COLOR]]$INFO[VideoPlayer.ChannelNumber,,.]$INFO[VideoPlayer.ChannelName,,: ]$INFO[VideoPlayer.Artist,, - ]$INFO[VideoPlayer.Album,, - ]$INFO[VideoPlayer.Title]</label>
+            <label>$INFO[VideoPlayer.TVShowTitle,,[COLOR=Highlight]  •  [/COLOR]]$INFO[VideoPlayer.Season,$LOCALIZE[31973],.]$INFO[VideoPlayer.Episode,,[COLOR=Highlight]  •  [/COLOR]]$INFO[VideoPlayer.ChannelNumberLabel,,.]$INFO[VideoPlayer.ChannelName,,: ]$INFO[VideoPlayer.Artist,, - ]$INFO[VideoPlayer.Album,, - ]$INFO[VideoPlayer.Title]</label>
           </control>
           <control type="textbox">
             <posx>300</posx>

--- a/1080i/DialogPVRChannelManager.xml
+++ b/1080i/DialogPVRChannelManager.xml
@@ -55,7 +55,7 @@
             <width>80</width>
             <align>center</align>
             <aligny>center</aligny>
-            <info>ListItem.ChannelNumber</info>
+            <info>ListItem.ChannelNumberLabel</info>
           </control>
           <control type="label" description="Main Label">
             <posx>90</posx>
@@ -97,7 +97,7 @@
             <align>center</align>
             <aligny>center</aligny>
             <textcolor>White2</textcolor>
-            <info>ListItem.ChannelNumber</info>
+            <info>ListItem.ChannelNumberLabel</info>
           </control>
           <control type="label" description="Main Label">
             <posx>90</posx>

--- a/1080i/DialogPVRChannelsOSD.xml
+++ b/1080i/DialogPVRChannelsOSD.xml
@@ -61,7 +61,7 @@
             <width>80</width>
             <align>center</align>
             <aligny>center</aligny>
-            <info>ListItem.ChannelNumber</info>
+            <info>ListItem.ChannelNumberLabel</info>
           </control>
           <control type="label" description="Main Label">
             <posx>160</posx>
@@ -120,7 +120,7 @@
             <width>80</width>
             <align>center</align>
             <aligny>center</aligny>
-            <info>ListItem.ChannelNumber</info>
+            <info>ListItem.ChannelNumberLabel</info>
           </control>
           <control type="label" description="Main Label">
             <posx>160</posx>

--- a/1080i/DialogPVRGroupManager.xml
+++ b/1080i/DialogPVRGroupManager.xml
@@ -179,7 +179,7 @@
                 <aligny>center</aligny>
                 <textcolor>grey2</textcolor>
                 <selectedcolor>selected</selectedcolor>
-                <label>$INFO[ListItem.ChannelNumber,(,) - ]$INFO[ListItem.ChannelName]</label>
+                <label>$INFO[ListItem.ChannelNumberLabel,(,) - ]$INFO[ListItem.ChannelName]</label>
               </control>
             </itemlayout>
             <focusedlayout height="68">
@@ -207,7 +207,7 @@
                 <aligny>center</aligny>
                 <textcolor>white</textcolor>
                 <selectedcolor>selected</selectedcolor>
-                <label>$INFO[ListItem.ChannelNumber,(,) - ]$INFO[ListItem.ChannelName]</label>
+                <label>$INFO[ListItem.ChannelNumberLabel,(,) - ]$INFO[ListItem.ChannelName]</label>
               </control>
             </focusedlayout>
           </control>
@@ -286,7 +286,7 @@
                 <aligny>center</aligny>
                 <textcolor>grey2</textcolor>
                 <selectedcolor>selected</selectedcolor>
-                <label>$INFO[ListItem.ChannelNumber,(,) - ]$INFO[ListItem.ChannelName]</label>
+                <label>$INFO[ListItem.ChannelNumberLabel,(,) - ]$INFO[ListItem.ChannelName]</label>
               </control>
             </itemlayout>
             <focusedlayout height="68">
@@ -314,7 +314,7 @@
                 <aligny>center</aligny>
                 <textcolor>white</textcolor>
                 <selectedcolor>selected</selectedcolor>
-                <label>$INFO[ListItem.ChannelNumber,(,) - ]$INFO[ListItem.ChannelName]</label>
+                <label>$INFO[ListItem.ChannelNumberLabel,(,) - ]$INFO[ListItem.ChannelName]</label>
               </control>
             </focusedlayout>
           </control>

--- a/1080i/DialogSeekBar.xml
+++ b/1080i/DialogSeekBar.xml
@@ -128,7 +128,7 @@
 	  <control type="label" description="Seek time label">
         <visible>![Player.Caching | Player.Seeking | player.forwarding | player.rewinding | Player.DisplayAfterSeek | [Player.Paused + System.IdleTime(4)]]</visible>
         <include>SeekbarLabels</include>
-        <label>$INFO[VideoPlayer.TVShowTitle,,[COLOR=Highlight]  •  [/COLOR]]$INFO[VideoPlayer.Season,$LOCALIZE[31973],.]$INFO[VideoPlayer.Episode,,[COLOR=Highlight]  •  [/COLOR]]$INFO[VideoPlayer.ChannelNumber,,.]$INFO[VideoPlayer.ChannelName,,: ]$INFO[VideoPlayer.Artist,, - ]$INFO[VideoPlayer.Album,, - ]$INFO[VideoPlayer.Title]</label>
+        <label>$INFO[VideoPlayer.TVShowTitle,,[COLOR=Highlight]  •  [/COLOR]]$INFO[VideoPlayer.Season,$LOCALIZE[31973],.]$INFO[VideoPlayer.Episode,,[COLOR=Highlight]  •  [/COLOR]]$INFO[VideoPlayer.ChannelNumberLabel,,.]$INFO[VideoPlayer.ChannelName,,: ]$INFO[VideoPlayer.Artist,, - ]$INFO[VideoPlayer.Album,, - ]$INFO[VideoPlayer.Title]</label>
       </control>
 	  <control type="label" description="Chapter Info with Player info">
         <visible>Player.ChapterCount + !VideoPlayer.Content(LiveTV)</visible>

--- a/1080i/MyPVRChannels.xml
+++ b/1080i/MyPVRChannels.xml
@@ -95,7 +95,7 @@
 							<width>80</width>
 							<align>center</align>
 							<aligny>center</aligny>
-							<info>ListItem.ChannelNumber</info>
+							<info>ListItem.ChannelNumberLabel</info>
 						</control>
 						<control type="label" description="Number">
 							<visible>Skin.HasSetting(HideEPGLogos)</visible>
@@ -105,7 +105,7 @@
 							<width>80</width>
 							<align>center</align>
 							<aligny>center</aligny>
-							<info>ListItem.ChannelNumber</info>
+							<info>ListItem.ChannelNumberLabel</info>
 						</control>
 						<control type="label" description="Main Label">
 							<posx>186</posx>
@@ -168,7 +168,7 @@
 							<width>80</width>
 							<align>center</align>
 							<aligny>center</aligny>
-							<info>ListItem.ChannelNumber</info>
+							<info>ListItem.ChannelNumberLabel</info>
 						</control>
 						<control type="label" description="Number">
 							<visible>Skin.HasSetting(HideEPGLogos)</visible>
@@ -178,7 +178,7 @@
 							<width>80</width>
 							<align>center</align>
 							<aligny>center</aligny>
-							<info>ListItem.ChannelNumber</info>
+							<info>ListItem.ChannelNumberLabel</info>
 						</control>
 						<control type="label" description="Main Label">
 							<posx>186</posx>

--- a/1080i/VideoFullScreen.xml
+++ b/1080i/VideoFullScreen.xml
@@ -95,9 +95,9 @@
 				</control>
 				<control type="label" id="1">
 					<description>LiveTV Info label</description>
-					<posx>400</posx>
+					<posx>430</posx>
 					<posy>-60</posy>
-					<width>720</width>
+					<width>690</width>
 					<height>125</height>
 					<font>InfoTitle</font>
 					<label>$INFO[VideoPlayer.ChannelName]</label>
@@ -107,8 +107,9 @@
 				</control>
 				<control type="label" id="1">
 						<width min="10" max="750">auto</width>
-						<posx>400</posx>
+						<posx>430</posx>
 						<posy>40</posy>
+                        <width>690</width>
 						<height>30</height>
 						<font>MainLabelBigTitle</font>
 						<label>$INFO[Player.Title]</label>

--- a/1080i/View_PVR.xml
+++ b/1080i/View_PVR.xml
@@ -218,7 +218,7 @@
 						<height>78</height>
 						<font>Details</font>
 						<align>center</align>
-						<info>ListItem.ChannelNumber</info>
+						<info>ListItem.ChannelNumberLabel</info>
 					</control>
 					<control type="label" id="1" description="Column 1 selected">
 						<visible>!Skin.HasSetting(HideEPGLogos)</visible>
@@ -265,7 +265,7 @@
 						<align>center</align>
 						<aligny>center</aligny>
 						<textcolor>White2</textcolor>
-						<info>ListItem.ChannelNumber</info>
+						<info>ListItem.ChannelNumberLabel</info>
 					</control>
 					<control type="label" id="1" description="Column 1 Focused">
 						<visible>!Skin.HasSetting(HideEPGLogos)</visible>


### PR DESCRIPTION
Here are my changes to support ATSC channel numbering.  As indicated in the forum, I have changed all occurrences of ChannelNumber to ChannelNumberLabel and adjusted a couple of positions and widths on the OSD to accomodate longer numbers. There are additional positioning changes that could be made, but I haven't taken a serious look at them yet.
