### PR TITLE
OSD: Center the third row above the video control row.

### DIFF
--- a/1080i/VideoFullScreen.xml
+++ b/1080i/VideoFullScreen.xml
@@ -122,7 +122,7 @@
 			</control>
 			<control type="grouplist" id="1">
 				<top>50</top>
-				<posx>710</posx>
+				<posx>669</posx>
 				<height>35</height>
 				<width>605</width>
 				<orientation>horizontal</orientation>


### PR DESCRIPTION
This PR centers the third row (Codec, Aspect Ratio ...), over the video control row in video OSD. Post #20 of the "Android - Movie quality info inside player" thread (http://forum.kodi.tv/showthread.php?tid=256862&page=2) further illustrates the line of code change.
