### PR TITLE
OSD: Center the second row above the video control row.

### DIFF
--- a/1080i/VideoOSD.xml
+++ b/1080i/VideoOSD.xml
@@ -23,7 +23,7 @@
     </control>
     <control type="grouplist" id="100">
       <top>900</top>
-      <left>30</left>
+      <left>19</left>
       <height>98</height>
       <width>1305</width>
       <align>right</align>


### PR DESCRIPTION
This PR centers the second row (Subtitles, Video Settings ...), over the video control row in video OSD. Post #20 of the "Android - Movie quality info inside player" thread (http://forum.kodi.tv/showthread.php?tid=256862&page=2) further illustrates the line of code change.
