### PR TITLE
Fix "GO PLEX" not going to Plex

### DIFF
--- a/1080i/Includes_Plexbmc.xml
+++ b/1080i/Includes_Plexbmc.xml
@@ -1320,6 +1320,7 @@
       <label>$LOCALIZE[31008]</label>
       <onclick>Skin.ToggleSetting(plexbmc)</onclick>
       <onclick>ReloadSkin()</onclick>
+	    <onclick>XBMC.RunScript(plugin.video.plexbmc,cacherefresh)</onclick>
     </item>
     <item id="56" description="go XBMC">
       <visible>System.HasAddon(plugin.video.plexbmc) + Skin.HasSetting(plexbmc)</visible>


### PR DESCRIPTION
Using Kodi 16.1 Jarvis clicking the "GO PLEX" button does not switch to the Plex view until refreshing PleXBMC. This will refresh PleXBMC when the "GO PLEX" button is clicked.