### PR TITLE
Fix addon shelf launch type

### DIFF
--- a/1080i/Includes_Shelf_Contents.xml
+++ b/1080i/Includes_Shelf_Contents.xml
@@ -365,10 +365,10 @@
           <param name="listitemcontent3">addons://sources/audio/</param>
           <param name="listitemcontent4">addons://sources/image/</param>
           <param name="listitemcontent5">addons://sources/executable/</param>
-          <param name="listitemtarget1">programs</param>
-          <param name="listitemtarget2">programs</param>
-          <param name="listitemtarget3">programs</param>
-          <param name="listitemtarget4">programs</param>
+          <param name="listitemtarget1" />
+          <param name="listitemtarget2">videos</param>
+          <param name="listitemtarget3">music</param>
+          <param name="listitemtarget4">pictures</param>
           <param name="listitemtarget5">programs</param>
         </include>
         <include content="ShelfList">


### PR DESCRIPTION
Causes issues with videos not launching from youtube etc. if accessed via the shelf