### PR TITLE
Fixed color "Details" in Green theme

### DIFF
--- a/colors/Green.xml
+++ b/colors/Green.xml
@@ -4,7 +4,7 @@
 	<color name="Grey2">FFBEBEBE</color>
 	<color name="Grey">FF5E5E5E</color>
 	<color name="Label2">FF898989</color>
-	<color name="Details">Details</color>
+	<color name="Details">FF777777</color>
 	<color name="White">FFCCCCCC</color>
 	<color name="White2">FFFFFFFF</color>
 	<color name="Red">FFfe3737</color>


### PR DESCRIPTION
Copypaste mishap in the color definition made the text of the
sub-menus below the main menu items of the navigational strip
pretty hard to read.
Excuse me for not knowing the correct terms for these GUI elements...