### PR TITLE
Set/Plot overlap issue

### DIFF
--- a/1080i/View_50_List.xml
+++ b/1080i/View_50_List.xml
@@ -69,7 +69,17 @@
         <param name="subheading">$VAR[panelsubheading]</param>
         <param name="plot">$VAR[Plots]</param>
         <param name="footer">$VAR[panelfooter]</param>
-        <param name="visibility">Container.content(addons) | Container.Content(episodes) | Container.Content(movies) | Container.Content(musicvideos) | Container.Content(seasons) | Container.Content(sets) | Container.Content(tvshows)</param>
+        <param name="visibility">Container.content(addons) | Container.Content(episodes) | Container.Content(movies) | Container.Content(musicvideos) | Container.Content(seasons) | Container.Content(tvshows)</param>
+      </include>
+      <include content="PanelTemplate">
+        <param name="top">355</param>
+        <param name="left">555</param>
+        <param name="height">410</param>
+        <param name="width">650</param>
+        <param name="heading">$VAR[panelheading]</param>
+        <param name="subheading">$VAR[panelsubheading]</param>
+        <param name="footer">$VAR[panelfooter]</param>
+        <param name="visibility">Container.Content(sets)</param>
       </include>
       <include content="PanelTemplate">
         <param name="top">355</param>

--- a/1080i/View_51_Panel.xml
+++ b/1080i/View_51_Panel.xml
@@ -61,7 +61,15 @@
         <param name="subheading">$VAR[panelsubheading]</param>
         <param name="plot">$VAR[Plots]</param>
         <param name="footer">$VAR[panelfooter]</param>
-        <param name="visibility">![Container.Content(artists) | Container.Content(albums) | Container.Content(images)]</param>
+        <param name="visibility">![Container.Content(artists) | Container.Content(albums) | Container.Content(images) | Container.Content(sets)]</param>
+      </include>
+      <include content="PanelTemplate">
+        <param name="top">345</param>
+        <param name="height">415</param>
+        <param name="heading">$VAR[panelheading]</param>
+        <param name="subheading">$VAR[panelsubheading]</param>
+        <param name="footer">$VAR[panelfooter]</param>
+        <param name="visibility">Container.Content(sets)</param>
       </include>
       <include content="PanelTemplate">
         <param name="top">345</param>

--- a/1080i/View_54_LowList.xml
+++ b/1080i/View_54_LowList.xml
@@ -57,7 +57,19 @@
         <param name="plot">$VAR[Plots]</param>
         <param name="footer">$VAR[panelfooter]</param>
         <param name="showfooter">false</param>
-        <param name="visibility">Container.content(addons) | Container.Content(episodes) | Container.Content(movies) | Container.Content(musicvideos) | Container.Content(seasons) | Container.Content(sets) | Container.Content(tvshows)</param>
+        <param name="visibility">Container.content(addons) | Container.Content(episodes) | Container.Content(movies) | Container.Content(musicvideos) | Container.Content(seasons) | Container.Content(tvshows)</param>
+      </include>
+      <include content="PanelTemplate">
+        <param name="lowpanel">true</param>
+        <param name="top">610</param>
+        <param name="left">355</param>
+        <param name="height">270</param>
+        <param name="width">850</param>
+        <param name="heading">$VAR[panelheading]</param>
+        <param name="subheading">$VAR[panelsubheading]</param>
+        <param name="footer">$VAR[panelfooter]</param>
+        <param name="showfooter">false</param>
+        <param name="visibility">Container.Content(sets)</param>
       </include>
       <include content="PanelTemplate">
         <param name="lowpanel">true</param>

--- a/1080i/View_55_BigPanel.xml
+++ b/1080i/View_55_BigPanel.xml
@@ -58,7 +58,15 @@
         <param name="subheading">$VAR[panelsubheading]</param>
         <param name="plot">$VAR[Plots]</param>
         <param name="footer">$VAR[panelfooter]</param>
-        <param name="visibility">![Container.Content(artists) | Container.Content(albums) | Container.Content(images)]</param>
+        <param name="visibility">![Container.Content(artists) | Container.Content(albums) | Container.Content(images) | Container.Content(sets)]</param>
+      </include>
+      <include content="PanelTemplate">
+        <param name="top">100</param>
+        <param name="height">640</param>
+        <param name="heading">$VAR[panelheading]</param>
+        <param name="subheading">$VAR[panelsubheading]</param>
+        <param name="footer">$VAR[panelfooter]</param>
+        <param name="visibility">Container.Content(sets)</param>
       </include>
       <include content="PanelTemplate">
         <param name="top">100</param>


### PR DESCRIPTION
Reference: #95 

There is a visual issue on some views in the movie set mode where the movie set plot overlaps with the list of movies in the set (see issue for image). Movie set plots are perhaps a new parameter, and that has caused this overlap issue on some views. The fix is to add special cases to List, LowList, Panel, and BigPanel (all of the relevant ones, the rest are not affected) so that the movie set plots are not displayed. Different sections of code handle the list and plot displays, and I believe that implementing a fix that allows both to be displayed would be too clunky, especially for cases where a set doesn't have a specified plot.

Since this fix applies to sets only through the `visibility` statement, it does not affect anything for other containers.